### PR TITLE
Password Change Notification

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -669,6 +669,7 @@ $(document).ready(function () {
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
 								if(result.status == 'success') {
+									OC.Notification.showTemporary(t('admin', result.status));
 								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -668,7 +668,9 @@ $(document).ready(function () {
 							OC.generateUrl('/settings/users/changepassword'),
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
-								if (result.status != 'success') {
+								if(result.status == 'success') {
+									OC.Notification.showTemporary(t('admin', 'User password updated'));
+								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}
 							}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -669,7 +669,6 @@ $(document).ready(function () {
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
 								if(result.status == 'success') {
-									OC.Notification.showTemporary(t('admin', 'User password updated'));
 								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}


### PR DESCRIPTION
Applied a new IF ELSE statement to provide a temporary success message
on updating a user password in settings. If status is not 'success' the
error message is returned as current.

This is a fix for: #25532
